### PR TITLE
Make cert-manager deployment script idempotent

### DIFF
--- a/cert-svc/deploy-cert-manager.sh
+++ b/cert-svc/deploy-cert-manager.sh
@@ -1,7 +1,15 @@
-kubectl create namespace cert-manager
-helm repo add jetstack https://charts.jetstack.io
+#!/bin/bash
+set -euo pipefail
+
+# Ensure the cert-manager namespace exists
+kubectl get namespace cert-manager >/dev/null 2>&1 || kubectl create namespace cert-manager
+
+# Add the jetstack repo and update repositories
+helm repo add jetstack https://charts.jetstack.io --force-update
 helm repo update
-helm install cert-manager jetstack/cert-manager \
+
+# Install or upgrade cert-manager
+helm upgrade --install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --set installCRDs=true
 


### PR DESCRIPTION
## Summary
- ensure cert-manager namespace is created only if missing
- use helm upgrade --install for idempotent cert-manager deployments and add repo force update
- harden deploy script with bash strict mode

## Testing
- `bash -n cert-svc/deploy-cert-manager.sh`
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*


------
https://chatgpt.com/codex/tasks/task_e_6898ddb270bc83309c5ac59273aa7fef