### PR TITLE
feat: add CloudNativePG deployment script

### DIFF
--- a/postgres/deploy-postgres.sh
+++ b/postgres/deploy-postgres.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure the cnpg-system namespace exists
+kubectl get namespace cnpg-system >/dev/null 2>&1 || kubectl create namespace cnpg-system
+
+# Add the CloudNativePG Helm repository and update
+helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update
+helm repo update
+
+# Install or upgrade the CloudNativePG operator
+helm upgrade --install cnpg cloudnative-pg/cloudnative-pg \
+  --namespace cnpg-system
+
+# Apply existing persistent volume and claim
+kubectl apply -f postgres-pv.yaml
+kubectl apply -f postgres-pvc.yaml
+
+# Apply the PostgreSQL cluster configuration using the existing claim
+kubectl apply -f postgres-cluster.yaml

--- a/postgres/postgres-cluster.yaml
+++ b/postgres/postgres-cluster.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+spec:
+  instances: 1
+  storage:
+    size: 20Gi
+    storageClass: manual
+    pvcTemplate:
+      metadata:
+        name: postgresql-pv-claim
+  bootstrap:
+    initdb:
+      database: app
+      owner: app


### PR DESCRIPTION
## Summary
- add script to install CloudNativePG operator and apply a PostgreSQL cluster
- configure PostgreSQL cluster to use pre-provisioned persistent volume and claim

## Testing
- `bash -n postgres/deploy-postgres.sh`
- `kubectl apply --dry-run=client -f postgres/postgres-pv.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f postgres/postgres-pvc.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f postgres/postgres-cluster.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898df15eca08330babb68dd477380dc