### PR TITLE
Add Grafana setup directory

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,10 @@
+# Grafana
+
+Helm values for deploying Grafana with nginx ingress and optional persistence.
+
+Install using:
+
+```
+helm repo add grafana https://grafana.github.io/helm-charts
+helm upgrade --install grafana grafana/grafana -f values.yaml
+```

--- a/grafana/values.yaml
+++ b/grafana/values.yaml
@@ -1,0 +1,18 @@
+adminUser: admin
+adminPassword: prom-operator
+service:
+  type: ClusterIP
+  port: 80
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-http"
+  hosts:
+    - grafana.merldev.com
+  tls:
+    - secretName: grafana-tls
+      hosts:
+        - grafana.merldev.com
+persistence:
+  enabled: false


### PR DESCRIPTION
## Summary
- add Grafana Helm values and basic install instructions

## Testing
- `python3 - <<'PY'
import yaml,sys
with open('grafana/values.yaml') as f:
    yaml.safe_load(f)
print('YAML valid')
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6898e1515cc08330bf98a7888fe7a086