### PR TITLE
chore: update Keycloak ingress domain

### DIFF
--- a/keycloak/ingress.yaml
+++ b/keycloak/ingress.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - keycloak.merl-app.com
+        - keycloak.merldev.com
       secretName: keycloak-tls
   rules:
-    - host: keycloak.merl-app.com
+    - host: keycloak.merldev.com
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Summary
- point Keycloak ingress at keycloak.merldev.com

## Testing
- `kubectl apply --dry-run=client -f keycloak/ingress.yaml` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*
- `pip install pyyaml` *(fails: proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_6898e3d63770833094da671bd0987aa2