### PR TITLE
Align PostgreSQL storage class with PV configuration

### DIFF
--- a/postgres/values.yaml
+++ b/postgres/values.yaml
@@ -5,5 +5,5 @@ primary:
   persistence:
     enabled: true
     existingClaim: postgresql-pv-claim  # Name of the PVC you created manually
-    storageClass: ""                # Leave empty when using existingClaim
+    storageClass: manual  # Must match storageClassName in postgres/postgres-pv.yaml
 


### PR DESCRIPTION
## Summary
- set `primary.persistence.storageClass` to `manual`
- explain that the storage class must match `postgres-pv.yaml`

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('postgres/values.yaml')"`
- `yamllint postgres/values.yaml` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898e3f65a3c8330854ffcd412f11e73